### PR TITLE
-fix SQLINTEGER to SQLLEN

### DIFF
--- a/src/slt_odbc3.c
+++ b/src/slt_odbc3.c
@@ -205,7 +205,6 @@ static int ODBC3_dropAllTables(ODBC3_Handles *pODBC3conn)
       rc = 1;
     }
   }
-
   if( !rc ){
     /* Loop through the rows in the result-set */
     do {
@@ -213,7 +212,7 @@ static int ODBC3_dropAllTables(ODBC3_Handles *pODBC3conn)
       if (SQL_SUCCEEDED(ret)) {
         /* Loop through the columns in the row */
         for( i=1; i<=columns; i++ ){
-          SQLINTEGER indicator;
+          SQLLEN indicator = 0;
           char zBuffer[512];
           /* retrieve column data as a string */
           ret = SQLGetData(stmt, 
@@ -568,7 +567,7 @@ static int ODBC3Query(
       if( SQL_SUCCEEDED(ret) ){
         /* Loop through the columns */
         for(i = 1; !rc && (i <= columns); i++){
-          SQLINTEGER indicator = 0;
+          SQLLEN indicator = 0;
           switch( zType[i-1] ){
             case 'T': {
               /* retrieve column data as a string */


### PR DESCRIPTION
-SQLINTEGER is the ODBC2 version of the value that's a 32-bit
 integer whereas SQLLEN is a 64-bit integer